### PR TITLE
Ability to handle custom tagName.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Attributes
 - **onComplete** (optional): A callback triggered when counting is done.
 - **digits** (optional): The number of digits to appear after the decimal point (default: 0).
 - **className** (optional): HTML class attribute for counter element.
+- **tagName** (optional): Element name that will be displayed (default: 'span').
 
 Test
 ----

--- a/src/__tests__/react-count-to-test.js
+++ b/src/__tests__/react-count-to-test.js
@@ -121,4 +121,16 @@ describe('CountTo', () => {
       expect(ReactDOM.findDOMNode(span).textContent).toEqual('2');
     });
   });
+
+  describe('with `tagName` prop', () => {
+    it('starts from 0, ends to 1', () => {
+      countTo = TestUtils.renderIntoDocument(
+        <CountTo to={1} speed={1} tagName={'div'} />
+      );
+      const div = TestUtils.findRenderedDOMComponentWithTag(countTo, 'div');
+      expect(ReactDOM.findDOMNode(div).textContent).toEqual('0');
+      jest.runAllTimers();
+      expect(ReactDOM.findDOMNode(div).textContent).toEqual('1');
+    });
+  });
 });

--- a/src/react-count-to.js
+++ b/src/react-count-to.js
@@ -79,11 +79,9 @@ const CountTo = React.createClass({
   },
 
   render() {
-    const { className, digits, tagName } = this.props;
+    const { className, digits, tagName: Tag } = this.props;
     const { counter } = this.state;
     const value = counter.toFixed(digits);
-
-    const Tag = tagName;
 
     return (
       <Tag className={className}>

--- a/src/react-count-to.js
+++ b/src/react-count-to.js
@@ -10,6 +10,7 @@ const CountTo = React.createClass({
     onComplete: React.PropTypes.func,
     digits: React.PropTypes.number,
     className: React.PropTypes.string,
+    tagName: React.PropTypes.string,
   },
 
   getDefaultProps() {
@@ -17,6 +18,7 @@ const CountTo = React.createClass({
       from: 0,
       delay: 100,
       digits: 0,
+      tagName: 'span',
     };
   },
 
@@ -77,14 +79,16 @@ const CountTo = React.createClass({
   },
 
   render() {
-    const { className, digits } = this.props;
+    const { className, digits, tagName } = this.props;
     const { counter } = this.state;
     const value = counter.toFixed(digits);
 
+    const Tag = tagName;
+
     return (
-      <span className={className}>
+      <Tag className={className}>
         {value}
-      </span>
+      </Tag>
     );
   },
 


### PR DESCRIPTION
For cases to get custom tagName. For example, I have `svg` element and want to put `text` element with counter, because I can't use `span` inside `svg`
![asd32](https://cloud.githubusercontent.com/assets/1328473/24150348/916109fc-0e56-11e7-95e3-1aff762544d9.gif)
Tests and Readme are updated