### PR TITLE
Replaced deprecated React.PropTypes and React.createClass

### DIFF
--- a/demo/public/index.js
+++ b/demo/public/index.js
@@ -1,45 +1,51 @@
-import React from 'react';
+import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
 import request from 'superagent';
 import CountTo from '../../dist/react-count-to';
 
-const App = React.createClass({
+class App extends Component {
+  constructor() {
+    super();
 
-  getInitialState() {
-    return {
+    this.state = {
       isLoading: true,
       to: 0,
     };
-  },
+
+    this.onComplete = this.onComplete.bind(this);
+    this.callback = this.callback.bind(this);
+    this.renderCountTo = this.renderCountTo.bind(this);
+    this.renderLoading = this.renderLoading.bind(this);
+  }
 
   componentDidMount() {
     request
       .get('https://api.github.com/repos/facebook/react')
       .end(this.callback);
-  },
+  }
 
   onComplete() {
     console.log('completed!');
-  },
+  }
 
   callback(err, res) {
     this.setState({
       isLoading: false,
       to: res.body.stargazers_count,
     });
-  },
+  }
 
   renderLoading() {
     return (
       <span>Loading...</span>
     );
-  },
+  }
 
   renderCountTo() {
     return (
       <CountTo to={this.state.to} speed={1000} onComplete={this.onComplete} />
     );
-  },
+  }
 
   render() {
     return (
@@ -48,8 +54,7 @@ const App = React.createClass({
         {this.state.isLoading ? this.renderLoading() : this.renderCountTo()}
       </div>
     );
-  },
-
-});
+  }
+}
 
 ReactDOM.render(<App />, document.getElementById('count-to'));

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "express": "^4.13.4",
     "jest-cli": "^12.0.2",
     "react": "^15.0.2",
-    "react-addons-test-utils": "^15.0.2",
     "react-dom": "^15.0.2",
     "superagent": "^2.0.0-alpha.3"
   },
@@ -63,7 +62,10 @@
     "unmockedModulePathPatterns": [
       "<rootDir>/node_modules/react/",
       "<rootDir>/node_modules/react-dom/",
-      "<rootDir>/node_modules/react-addons-test-utils/"
+      "<rootDir>/node_modules/prop-types/"
     ]
+  },
+  "dependencies": {
+    "prop-types": "^15.5.8"
   }
 }

--- a/src/__tests__/react-count-to-test.js
+++ b/src/__tests__/react-count-to-test.js
@@ -1,8 +1,8 @@
 jest.unmock('../react-count-to');
 
 import React from 'react';
-import ReactDOM from 'react-dom';
-import TestUtils from 'react-addons-test-utils';
+import { findDOMNode } from 'react-dom';
+import TestUtils from 'react-dom/test-utils';
 import CountTo from '../react-count-to';
 
 describe('CountTo', () => {
@@ -14,9 +14,9 @@ describe('CountTo', () => {
         <CountTo to={1} speed={1} />
       );
       const span = TestUtils.findRenderedDOMComponentWithTag(countTo, 'span');
-      expect(ReactDOM.findDOMNode(span).textContent).toEqual('0');
+      expect(findDOMNode(span).textContent).toEqual('0');
       jest.runAllTimers();
-      expect(ReactDOM.findDOMNode(span).textContent).toEqual('1');
+      expect(findDOMNode(span).textContent).toEqual('1');
     });
   });
 
@@ -26,7 +26,7 @@ describe('CountTo', () => {
         <CountTo from={1} to={1} speed={1} />
       );
       const span = TestUtils.findRenderedDOMComponentWithTag(countTo, 'span');
-      expect(ReactDOM.findDOMNode(span).textContent).toEqual('1');
+      expect(findDOMNode(span).textContent).toEqual('1');
     });
   });
 
@@ -56,9 +56,9 @@ describe('CountTo', () => {
         <CountTo from={-1} to={1} speed={1} />
       );
       const span = TestUtils.findRenderedDOMComponentWithTag(countTo, 'span');
-      expect(ReactDOM.findDOMNode(span).textContent).toEqual('-1');
+      expect(findDOMNode(span).textContent).toEqual('-1');
       jest.runAllTimers();
-      expect(ReactDOM.findDOMNode(span).textContent).toEqual('1');
+      expect(findDOMNode(span).textContent).toEqual('1');
     });
 
     it('starts from 1, ends to -1', () => {
@@ -66,9 +66,9 @@ describe('CountTo', () => {
         <CountTo from={1} to={-1} speed={1} />
       );
       const span = TestUtils.findRenderedDOMComponentWithTag(countTo, 'span');
-      expect(ReactDOM.findDOMNode(span).textContent).toEqual('1');
+      expect(findDOMNode(span).textContent).toEqual('1');
       jest.runAllTimers();
-      expect(ReactDOM.findDOMNode(span).textContent).toEqual('-1');
+      expect(findDOMNode(span).textContent).toEqual('-1');
     });
 
     it('starts sfrom -1, ends to -2', () => {
@@ -76,9 +76,9 @@ describe('CountTo', () => {
         <CountTo from={-1} to={-2} speed={1} />
       );
       const span = TestUtils.findRenderedDOMComponentWithTag(countTo, 'span');
-      expect(ReactDOM.findDOMNode(span).textContent).toEqual('-1');
+      expect(findDOMNode(span).textContent).toEqual('-1');
       jest.runAllTimers();
-      expect(ReactDOM.findDOMNode(span).textContent).toEqual('-2');
+      expect(findDOMNode(span).textContent).toEqual('-2');
     });
   });
 
@@ -88,9 +88,9 @@ describe('CountTo', () => {
         <CountTo from={-0.5} to={0.5} speed={1} digits={1} />
       );
       const span = TestUtils.findRenderedDOMComponentWithTag(countTo, 'span');
-      expect(ReactDOM.findDOMNode(span).textContent).toEqual('-0.5');
+      expect(findDOMNode(span).textContent).toEqual('-0.5');
       jest.runAllTimers();
-      expect(ReactDOM.findDOMNode(span).textContent).toEqual('0.5');
+      expect(findDOMNode(span).textContent).toEqual('0.5');
     });
   });
 
@@ -110,15 +110,15 @@ describe('CountTo', () => {
         <Parent />
       );
       const span = TestUtils.findRenderedDOMComponentWithTag(parent, 'span');
-      expect(ReactDOM.findDOMNode(span).textContent).toEqual('0');
+      expect(findDOMNode(span).textContent).toEqual('0');
       jest.runAllTimers();
-      expect(ReactDOM.findDOMNode(span).textContent).toEqual('1');
+      expect(findDOMNode(span).textContent).toEqual('1');
       parent.setState({
         to: 2,
       });
-      expect(ReactDOM.findDOMNode(span).textContent).toEqual('0');
+      expect(findDOMNode(span).textContent).toEqual('0');
       jest.runAllTimers();
-      expect(ReactDOM.findDOMNode(span).textContent).toEqual('2');
+      expect(findDOMNode(span).textContent).toEqual('2');
     });
   });
 
@@ -128,9 +128,9 @@ describe('CountTo', () => {
         <CountTo to={1} speed={1} tagName={'div'} />
       );
       const div = TestUtils.findRenderedDOMComponentWithTag(countTo, 'div');
-      expect(ReactDOM.findDOMNode(div).textContent).toEqual('0');
+      expect(findDOMNode(div).textContent).toEqual('0');
       jest.runAllTimers();
-      expect(ReactDOM.findDOMNode(div).textContent).toEqual('1');
+      expect(findDOMNode(div).textContent).toEqual('1');
     });
   });
 
@@ -144,7 +144,7 @@ describe('CountTo', () => {
       expect(fn.mock.calls.length).toBe(3);
       expect(fn).lastCalledWith('1');
       const span = TestUtils.findRenderedDOMComponentWithTag(countTo, 'span');
-      expect(ReactDOM.findDOMNode(span).textContent).toEqual('1');
+      expect(findDOMNode(span).textContent).toEqual('1');
     });
   });
 });

--- a/src/__tests__/react-count-to-test.js
+++ b/src/__tests__/react-count-to-test.js
@@ -1,6 +1,6 @@
 jest.unmock('../react-count-to');
 
-import React from 'react';
+import React, { Component } from 'react';
 import { findDOMNode } from 'react-dom';
 import TestUtils from 'react-dom/test-utils';
 import CountTo from '../react-count-to';
@@ -96,16 +96,17 @@ describe('CountTo', () => {
 
   describe('when receive new props', () => {
     it('starts from 0, ends to 1', () => {
-      const Parent = React.createClass({
-        getInitialState() {
-          return {
+      class Parent extends Component {
+        constructor() {
+          super();
+          this.state = {
             to: 1,
           };
-        },
+        }
         render() {
           return <CountTo to={this.state.to} speed={1} />;
-        },
-      });
+        }
+      }
       const parent = TestUtils.renderIntoDocument(
         <Parent />
       );

--- a/src/react-count-to.js
+++ b/src/react-count-to.js
@@ -1,39 +1,43 @@
-import React, { PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
-const CountTo = React.createClass({
+const propTypes = {
+  from: PropTypes.number,
+  to: PropTypes.number.isRequired,
+  speed: PropTypes.number.isRequired,
+  delay: PropTypes.number,
+  onComplete: PropTypes.func,
+  digits: PropTypes.number,
+  className: PropTypes.string,
+  tagName: PropTypes.string,
+  children: PropTypes.func,
+};
 
-  propTypes: {
-    from: PropTypes.number,
-    to: PropTypes.number.isRequired,
-    speed: PropTypes.number.isRequired,
-    delay: PropTypes.number,
-    onComplete: PropTypes.func,
-    digits: PropTypes.number,
-    className: PropTypes.string,
-    tagName: PropTypes.string,
-    children: PropTypes.func,
-  },
+const defaultProps = {
+  from: 0,
+  delay: 100,
+  digits: 0,
+  tagName: 'span',
+};
 
-  getDefaultProps() {
-    return {
-      from: 0,
-      delay: 100,
-      digits: 0,
-      tagName: 'span',
-    };
-  },
+class CountTo extends Component {
+  constructor(props) {
+    super();
 
-  getInitialState() {
-    const { from } = this.props;
+    const { from } = props;
 
-    return {
+    this.state = {
       counter: from,
     };
-  },
+
+    this.start = this.start.bind(this);
+    this.clear = this.clear.bind(this);
+    this.next = this.next.bind(this);
+  }
 
   componentDidMount() {
     this.start();
-  },
+  }
 
   componentWillReceiveProps(nextProps) {
     const { from, to } = this.props;
@@ -41,15 +45,18 @@ const CountTo = React.createClass({
     if (nextProps.to !== to || nextProps.from !== from) {
       this.start();
     }
-  },
+  }
 
   componentWillUnmount() {
     this.clear();
-  },
+  }
 
   start() {
     this.clear();
-    this.setState(this.getInitialState(), () => {
+    const { from } = this.props;
+    this.setState({
+      counter: from,
+    }, () => {
       const { delay, speed, to } = this.props;
       const { counter } = this.state;
       this.loopsCounter = 0;
@@ -57,7 +64,7 @@ const CountTo = React.createClass({
       this.increment = (to - counter) / this.loops;
       this.interval = setInterval(this.next, delay);
     });
-  },
+  }
 
   next() {
     if (this.loopsCounter < this.loops) {
@@ -73,11 +80,11 @@ const CountTo = React.createClass({
         onComplete();
       }
     }
-  },
+  }
 
   clear() {
     clearInterval(this.interval);
-  },
+  }
 
   render() {
     const { className, digits, tagName: Tag, children: fn } = this.props;
@@ -93,8 +100,10 @@ const CountTo = React.createClass({
         {value}
       </Tag>
     );
-  },
+  }
+}
 
-});
+CountTo.propTypes = propTypes;
+CountTo.defaultProps = defaultProps;
 
 export default CountTo;


### PR DESCRIPTION
According to https://facebook.github.io/react/docs/typechecking-with-proptypes.html

> Note: React.PropTypes is deprecated as of React v15.5. Please use the prop-types library instead.

This PR also replaces `React.createClass` with `Class` component, removing warning about deprecated construct.